### PR TITLE
Change PackageLicense to PackageLicenseExpression

### DIFF
--- a/src/Serilog.Enrichers.Demystifier/Serilog.Enrichers.Demystifier.csproj
+++ b/src/Serilog.Enrichers.Demystifier/Serilog.Enrichers.Demystifier.csproj
@@ -12,7 +12,7 @@
     <PackageTags>serilog;demystifier</PackageTags>
     <PackageIcon>serilog-community-nuget.png</PackageIcon>
     <PackageProject>https://github.com/Megasware128/serilog-enrichers-demystifier</PackageProject>
-    <PackageLicense>http://www.apache.org/licenses/LICENSE-2.0</PackageLicense>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
PackageLicense is a deprecated option and PackageLicenseExpression is recommended. This will also make it easier for tools to identify the license and not report "Unknown"

This is also discribed in the [guidelines from Microsoft](https://docs.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices?msclkid=c14314f2c6cb11eca48ed5861c88dd1b#licensing)